### PR TITLE
Post install

### DIFF
--- a/ansible-ipi-install/roles/add-provisioner/tasks/main.yml
+++ b/ansible-ipi-install/roles/add-provisioner/tasks/main.yml
@@ -12,10 +12,6 @@
     hostname: "{{ provisioner_hostname }}"
     user: "kni"
 
-- name: python interpreter
-  set_fact:
-    python_interpreter: "{{ (python_version.stderr_lines|length > 0) | ternary('/usr/libexec/platform-python', '/usr/bin/python') }}"
-
 - name: add provisioner to inventory file
   add_host:
     name: "{{ provisioner_hostname }}"
@@ -23,5 +19,5 @@
     ansible_host: "{{ provisioner_hostname }}"
     ansible_ssh_private_key_file: "{{ ansible_ssh_key }}"
     ansible_user: "kni"
-    ansible_python_interpreter: "{{ python_interpreter }}"
+    ansible_python_interpreter: "/usr/bin/python3"
 

--- a/ansible-ipi-install/roles/post-install/defaults/main.yml
+++ b/ansible-ipi-install/roles/post-install/defaults/main.yml
@@ -1,0 +1,9 @@
+ovn_namespace: openshift-ovn-kubernetes
+openshift_network_type: OVNKubernetes
+openshift_prometheus_retention_period: 15d
+openshift_prometheus_storage_class: 10Gi
+openshift_prometheus_storage_size: standard
+openshift_alertmanager_storage_class: standard
+openshift_alertmanager_storage_size: 2Gi
+thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"
+thanos_receiver_url: "{{ lookup('env', 'THANOS_RECEIVER_URL')|default('http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive', true) }}"

--- a/ansible-ipi-install/roles/post-install/defaults/main.yml
+++ b/ansible-ipi-install/roles/post-install/defaults/main.yml
@@ -9,3 +9,6 @@ openshift_alertmanager_storage_size: 2Gi
 openshift_infra_node_selector: 'node-role.kubernetes.io/infra: ""'
 thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"
 thanos_receiver_url: "{{ lookup('env', 'THANOS_RECEIVER_URL')|default('http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive', true) }}"
+openshift_toggle_infra_node: true
+openshift_toggle_workload_node: true
+dittybopper_enable: true

--- a/ansible-ipi-install/roles/post-install/defaults/main.yml
+++ b/ansible-ipi-install/roles/post-install/defaults/main.yml
@@ -1,8 +1,8 @@
 ovn_namespace: openshift-ovn-kubernetes
 openshift_network_type: OVNKubernetes
 openshift_prometheus_retention_period: 15d
-openshift_prometheus_storage_class: 10Gi
-openshift_prometheus_storage_size: standard
+openshift_prometheus_storage_class: standard
+openshift_prometheus_storage_size: 10Gi
 openshift_alertmanager_storage_class: standard
 openshift_alertmanager_storage_size: 2Gi
 thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"

--- a/ansible-ipi-install/roles/post-install/defaults/main.yml
+++ b/ansible-ipi-install/roles/post-install/defaults/main.yml
@@ -6,5 +6,6 @@ openshift_prometheus_storage_class: standard
 openshift_prometheus_storage_size: 10Gi
 openshift_alertmanager_storage_class: standard
 openshift_alertmanager_storage_size: 2Gi
+openshift_infra_node_selector: 'node-role.kubernetes.io/infra: ""'
 thanos_enable: "{{ lookup('env', 'THANOS_ENABLE')|default(false, true) }}"
 thanos_receiver_url: "{{ lookup('env', 'THANOS_RECEIVER_URL')|default('http://thanos-receive-thanos.apps.keith-cluster.perfscale.devcluster.openshift.com/api/v1/receive', true) }}"

--- a/ansible-ipi-install/roles/post-install/defaults/main.yml
+++ b/ansible-ipi-install/roles/post-install/defaults/main.yml
@@ -1,6 +1,7 @@
 ovn_namespace: openshift-ovn-kubernetes
 openshift_network_type: OVNKubernetes
 openshift_prometheus_retention_period: 15d
+persistent_monitoring_enable: false
 openshift_prometheus_storage_class: standard
 openshift_prometheus_storage_size: 10Gi
 openshift_alertmanager_storage_class: standard

--- a/ansible-ipi-install/roles/post-install/tasks/70_deploy_dittybopper.yml
+++ b/ansible-ipi-install/roles/post-install/tasks/70_deploy_dittybopper.yml
@@ -1,0 +1,13 @@
+---
+- name: clone dittybopper
+  git:
+    repo: 'https://github.com/cloud-bulldozer/performance-dashboards.git'
+    dest: "{{ ansible_user_dir }}/performance-dashboards"
+    force: yes
+
+- name: Deploy mutable Grafana
+  command: ./deploy.sh
+  args:
+    chdir: "{{ ansible_user_dir }}/performance-dashboards/dittybopper"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"

--- a/ansible-ipi-install/roles/post-install/tasks/main.yml
+++ b/ansible-ipi-install/roles/post-install/tasks/main.yml
@@ -73,23 +73,11 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_workload_node|bool
 
-
-- block:
-  - name: Copy new cluster-monitoring-config
-    template:
-      src: cluster-monitoring-config.yml.j2
-      dest: "{{ ansible_user_dir }}/{{ dynamic_deploy_path }}/cluster-monitoring-config.yml"
-    register: copy_yaml
-  
-  - set_fact:
-      cluster_monitoring_yaml_path: "{{ copy_yaml.dest }}"
-
-  - name: Replace the cluster-monitoring-config ConfigMap
-    shell: |
-      oc create -f {{ cluster_monitoring_yaml_path }}
-    ignore_errors: yes
-    environment:
-      KUBECONFIG: "{{ kubeconfig_path }}"
+- name: Copy new cluster-monitoring-config
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig_path }}"
+    name: openshift-windows-machine-config-operator
+    template: cluster-monitoring-config.yml.j2
   when: openshift_toggle_infra_node|bool
 
 - name: Apply new nodeSelector to infra workload components
@@ -112,17 +100,5 @@
 
 
 - name: Deploy dittybopper
-  block:
-    - name: clone dittybopper
-      git:
-        repo: 'https://github.com/cloud-bulldozer/performance-dashboards.git'
-        dest: "{{ ansible_user_dir }}/performance-dashboards"
-        force: yes
-
-    - name: Deploy mutable Grafana
-      command: ./deploy.sh
-      args:
-        chdir: "{{ ansible_user_dir }}/performance-dashboards/dittybopper"
-      environment:
-        KUBECONFIG: "{{ kubeconfig_path }}"
+  include_tasks: 70_deploy_dittybopper.yml
   when: dittybopper_enable

--- a/ansible-ipi-install/roles/post-install/tasks/main.yml
+++ b/ansible-ipi-install/roles/post-install/tasks/main.yml
@@ -90,10 +90,6 @@
         '{"spec": {"nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}}}}}'
       type: "--type merge"
 
-    - namespace: openshift-image-registry
-      object: deployment.apps/image-registry
-      patch: |
-         '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""}}}}}'
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: openshift_toggle_infra_node|bool

--- a/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  config.yaml: |
+    prometheusOperator:
+      baseImage: quay.io/coreos/prometheus-operator
+      prometheusConfigReloaderBaseImage: quay.io/coreos/prometheus-config-reloader
+      configReloaderBaseImage: quay.io/coreos/configmap-reload
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+    prometheusK8s:
+{% if thanos_enable %}
+      externalLabels:
+        openshift_cluster_name: {{ cluster_name.stdout }}
+        openshift_network_type: {{ openshift_network_type }}
+        openshift_version: {{ ocp_version.stdout }}
+        openshift_platform: {{ platform }}
+      remoteWrite:
+        - url: {{ thanos_receiver_url }}
+{% endif %}
+      retention: {{openshift_prometheus_retention_period}}
+      baseImage: openshift/prometheus
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      volumeClaimTemplate:
+        spec:
+          storageClassName: {{openshift_prometheus_storage_class}}
+          resources:
+            requests:
+              storage: {{openshift_prometheus_storage_size}}
+    alertmanagerMain:
+      baseImage: openshift/prometheus-alertmanager
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      volumeClaimTemplate:
+        spec:
+          storageClassName: {{openshift_alertmanager_storage_class}}
+          resources:
+            requests:
+              storage: {{openshift_alertmanager_storage_size}}
+    nodeExporter:
+      baseImage: openshift/prometheus-node-exporter
+    kubeRbacProxy:
+      baseImage: quay.io/coreos/kube-rbac-proxy
+    kubeStateMetrics:
+      baseImage: quay.io/coreos/kube-state-metrics
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+    grafana:
+      baseImage: grafana/grafana
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+    auth:
+      baseImage: openshift/oauth-proxy
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring

--- a/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -7,7 +7,7 @@ data:
       prometheusConfigReloaderBaseImage: quay.io/coreos/prometheus-config-reloader
       configReloaderBaseImage: quay.io/coreos/configmap-reload
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
     prometheusK8s:
 {% if thanos_enable %}
       externalLabels:
@@ -21,7 +21,7 @@ data:
       retention: {{openshift_prometheus_retention_period}}
       baseImage: openshift/prometheus
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
 {% if persistent_monitoring_enable %}
       volumeClaimTemplate:
         spec:
@@ -33,7 +33,7 @@ data:
     alertmanagerMain:
       baseImage: openshift/prometheus-alertmanager
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
 {% if persistent_monitoring_enable %}
       volumeClaimTemplate:
         spec:
@@ -49,16 +49,25 @@ data:
     kubeStateMetrics:
       baseImage: quay.io/coreos/kube-state-metrics
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
     grafana:
       baseImage: grafana/grafana
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
     auth:
       baseImage: openshift/oauth-proxy
+    telemeterClient:
+      nodeSelector:
+        {{ openshift_infra_node_selector  }}
     k8sPrometheusAdapter:
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        {{ openshift_infra_node_selector  }}
+    openshiftStateMetrics:
+      nodeSelector:
+        {{ openshift_infra_node_selector  }}
+    thanosQuerier:
+      nodeSelector:
+        {{ openshift_infra_node_selector  }}
 metadata:
   name: cluster-monitoring-config
   namespace: openshift-monitoring

--- a/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
+++ b/ansible-ipi-install/roles/post-install/templates/cluster-monitoring-config.yml.j2
@@ -22,22 +22,26 @@ data:
       baseImage: openshift/prometheus
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+{% if persistent_monitoring_enable %}
       volumeClaimTemplate:
         spec:
           storageClassName: {{openshift_prometheus_storage_class}}
           resources:
             requests:
               storage: {{openshift_prometheus_storage_size}}
+{% endif %}
     alertmanagerMain:
       baseImage: openshift/prometheus-alertmanager
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+{% if persistent_monitoring_enable %}
       volumeClaimTemplate:
         spec:
           storageClassName: {{openshift_alertmanager_storage_class}}
           resources:
             requests:
               storage: {{openshift_alertmanager_storage_size}}
+{% endif %}
     nodeExporter:
       baseImage: openshift/prometheus-node-exporter
     kubeRbacProxy:


### PR DESCRIPTION
Tested with: `ansible-playbook  -i inventory/jetski/hosts -e openshift_toggle_ovn_patch=false -epost_install=true -eopenshift_toggle_infra_node=true -eopenshift_toggle_workload_node=true -e dittybopper_enable=true post-install.yml -vvv`

image-registry removed by default in bare metal installs, so added a switch for now in case. We can remove entirely.
```
https://docs.openshift.com/container-platform/4.11/registry/configuring-registry-operator.html#registry-removed_configuring-registry-operator

[kni@f08-h17-b01-5039ms ~]$ oc get configs.imageregistry.operator.openshift.io -o yaml
    managementState: Removed
```